### PR TITLE
Add option to conf.json for custom log file location.

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -126,6 +126,10 @@ Create a file and copy the contents of conf.json.example file in it. Name this f
     environment variable set, emails reporting any errors logged by the server
     will be sent to the addresses listed here.
 
+  - ``UNHANGOUT_LOG_DIR``: Path to the directory for log file storage. Must be
+    writeable by the user running the Node process. Relative paths will be
+    appended to the application root. Default is ``logs``.
+
   - ``TESTING_SELENIUM_PATH``: The path to "selenium-server-standalone.jar",
     required to run tests with selenium.
 

--- a/conf.json.example
+++ b/conf.json.example
@@ -31,6 +31,7 @@
     "UNHANGOUT_CERTIFICATE":"ssl/cert.pem",
 
     "EMAIL_LOG_RECIPIENTS": ["sysadmin1@example.com"],
+    "UNHANGOUT_LOG_DIR": "logs",
     "TESTING_SELENIUM_PATH": "bin/selenium-server-standalone.jar",
     "TESTING_SELENIUM_VERBOSE": false,
     "TESTING_FIREFOX_BIN": null

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -6,10 +6,13 @@ var winston = require('winston'),
     winstonMail = require('winston-mail'),
     _ = require('underscore');
 
+var logDirSetting = _.isEmpty(conf.UNHANGOUT_LOG_DIR) ? "logs" : conf.UNHANGOUT_LOG_DIR;
+var logDir = logDirSetting.charAt(0) === '/' ? logDirSetting : __dirname + '/../' + logDirSetting;
+
 var logger = new (winston.Logger)();
 if (process.env.NODE_ENV === "production") {
     logger.add(winston.transports.File, {
-        filename: __dirname + '/../logs/server.log',
+        filename: logDir + '/server.log',
         level: 'info'
     });
     if (conf.EMAIL_LOG_RECIPIENTS && conf.EMAIL_LOG_RECIPIENTS.length > 0) {
@@ -52,7 +55,7 @@ if (process.env.NODE_ENV === "production") {
 var logFileName = process.env.NODE_LOAD_TESTING ? "loadtest.log" : "analytics.log";
 var analyticsLogger = new (winston.Logger)();
 analyticsLogger.add(winston.transports.File, {
-    filename: __dirname + "/../logs/" + logFileName,
+    filename: logDir + "/" + logFileName,
     level: 'info',
     timestamp: true,
     maxsize: 10000000 // 10 MB

--- a/lib/options.js
+++ b/lib/options.js
@@ -13,6 +13,7 @@ var options = _.extend({
     UNHANGOUT_REDIS_DB: 0,
     UNHANGOUT_SESSION_SECRET: "fake secret",
     UNHANGOUT_SERVER_EMAIL_ADDRESS: "node@localhost",
+    UNHANGOUT_LOG_DIR: "logs",
     EVENT_EDIT_NOTIFICATION_DELAY: 60000 * 5,
     // Permit more lag in non-production environments. Testing in particular
     // maxes out the server to maximize execution speed.


### PR DESCRIPTION
Helpful for conforming with http://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard

Coded to be backwards compatible with existing config files, if UNHANGOUT_LOG_DIR isn't set, 'logs' in the root application dir is used.